### PR TITLE
Improve chatbot close control and floating toggle

### DIFF
--- a/helpdesk-frontend/src/components/ChatBotWidget.css
+++ b/helpdesk-frontend/src/components/ChatBotWidget.css
@@ -8,24 +8,48 @@
 }
 
 .chatbot-button {
-  width: 64px;
+  min-width: 64px;
   height: 64px;
-  border-radius: 20px;
+  border-radius: 32px;
   border: none;
   background: linear-gradient(135deg, rgba(0, 33, 71, 0.92), rgba(10, 90, 180, 0.92));
   color: #fff;
-  font-size: 1.8rem;
   cursor: pointer;
   box-shadow: 0 18px 36px rgba(0, 33, 71, 0.35);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  gap: 14px;
+  padding: 0 26px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
 .chatbot-button:hover {
   transform: translateY(-4px);
   box-shadow: 0 22px 42px rgba(0, 33, 71, 0.38);
+  background: linear-gradient(135deg, rgba(12, 75, 155, 0.98), rgba(40, 140, 240, 0.98));
+}
+
+.chatbot-button__icon {
+  font-size: 1.6rem;
+  line-height: 1;
+  display: inline-flex;
+}
+
+.chatbot-button__text {
+  white-space: nowrap;
+}
+
+.chatbot-button:not(.open) {
+  width: 64px;
+  padding: 0;
+}
+
+.chatbot-button:not(.open) .chatbot-button__text {
+  display: none;
 }
 
 .chatbot-window {
@@ -70,28 +94,6 @@
   color: rgba(255, 255, 255, 0.75);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-}
-
-
-.chatbot-header__close {
-  background: rgba(255, 255, 255, 0.18);
-  border: none;
-  color: #0f1f3d;
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.chatbot-header__close:hover,
-.chatbot-header__close:focus-visible {
-  background: rgba(255, 255, 255, 0.28);
-  transform: translateY(-2px);
-  box-shadow: 0 10px 18px rgba(12, 28, 68, 0.25);
-  outline: none;
 }
 
 

--- a/helpdesk-frontend/src/components/ChatBotWidget.jsx
+++ b/helpdesk-frontend/src/components/ChatBotWidget.jsx
@@ -308,8 +308,15 @@ export default function ChatBotWidget({ userId }) {
 
   return (
     <div className={`chatbot-widget ${isOpen ? 'open' : ''}`}>
-      <button className="chatbot-button" onClick={handleToggle}>
-        {isOpen ? 'Cerrar' : 'Chat'}
+      <button
+        className={`chatbot-button ${isOpen ? 'open' : ''}`}
+        onClick={handleToggle}
+        aria-label={isOpen ? 'Cerrar asistente virtual' : 'Abrir asistente virtual'}
+      >
+        <span className="chatbot-button__icon" aria-hidden="true">
+          {isOpen ? '✕' : '💬'}
+        </span>
+        <span className="chatbot-button__text">{isOpen ? 'Cerrar' : 'Hablar con EMI'}</span>
       </button>
 
       {isOpen && (
@@ -319,7 +326,6 @@ export default function ChatBotWidget({ userId }) {
               <span className="chatbot-header__title">Asistente EMI</span>
               <span className="chatbot-header__subtitle">Soporte Cochabamba</span>
             </div>
-            <button className="chatbot-header__close" onClick={handleToggle}>Cerrar</button>
           </div>
 
           <div className="chatbot-messages">


### PR DESCRIPTION
## Summary
- remove the duplicate close control from the chatbot header to avoid redundant options
- restyle the floating chatbot toggle button with iconography and clearer labeling
- add accessibility-focused aria labeling while keeping the control responsive

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e5518f69888329bf19ba1e4a07d337