### PR TITLE
Add EMI logo to dashboard headers

### DIFF
--- a/helpdesk-frontend/src/components/AdminDashboard.css
+++ b/helpdesk-frontend/src/components/AdminDashboard.css
@@ -1,4 +1,4 @@
-/* Estilos renovados para el panel de administración */
+/* Estilos renovados para el panel de administraciÃ³n */
 .admin-dashboard {
   --header-height: 74px;
   --sidebar-width: 260px;
@@ -73,21 +73,22 @@
 
 .admin-header h1 {
   display: flex;
-  align-items: baseline;
-  gap: 6px;
+  align-items: center;
+  gap: 12px;
   font-size: 1.6rem;
   font-weight: 700;
+  margin: 0;
 }
 
 .logo-part {
   color: #fff;
 }
 
-.logo-emi {
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.82);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.emi-logo {
+  height: 34px;
+  width: auto;
+  display: block;
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.28));
 }
 
 .header-right {

--- a/helpdesk-frontend/src/components/AdminDashboard.jsx
+++ b/helpdesk-frontend/src/components/AdminDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 
 import './AdminDashboard.css';
+import emiLogo from '../assets/ESCUELA-MILITAR-DE-INGENIERIA.png';
 
 import {
 
@@ -270,11 +271,11 @@ export default function AdminDashboard({ onLogout, token, role }) {
 
           </button>
 
-          <h1>
+          <h1 className="app-logo">
 
             <span className="logo-part">HelpDesk</span>
 
-            <span className="logo-emi">EMI</span>
+            <img src={emiLogo} alt="Logo EMI" className="emi-logo" />
 
           </h1>
 

--- a/helpdesk-frontend/src/components/TechnicianDashboard.css
+++ b/helpdesk-frontend/src/components/TechnicianDashboard.css
@@ -25,8 +25,8 @@
   box-shadow: 0 14px 36px rgba(4, 120, 87, 0.24);
 }
 
-.technician-theme .logo-emi {
-  color: rgba(255, 255, 255, 0.86);
+.technician-theme .emi-logo {
+  opacity: 0.94;
 }
 
 .technician-theme .admin-content {

--- a/helpdesk-frontend/src/components/TechnicianDashboard.jsx
+++ b/helpdesk-frontend/src/components/TechnicianDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import './AdminDashboard.css';
 import './TechnicianDashboard.css';
+import emiLogo from '../assets/ESCUELA-MILITAR-DE-INGENIERIA.png';
 import {
   FiHome,
   FiMessageSquare,
@@ -178,9 +179,9 @@ export default function TechnicianDashboard({ onLogout, token, role }) {
           <button className="menu-toggle" onClick={() => setSidebarOpen(!sidebarOpen)}>
             {sidebarOpen ? <FiX /> : <FiMenu />}
           </button>
-          <h1>
+          <h1 className="app-logo">
             <span className="logo-part">HelpDesk</span>
-            <span className="logo-emi">TECH</span>
+            <img src={emiLogo} alt="Logo EMI" className="emi-logo" />
           </h1>
         </div>
         

--- a/helpdesk-frontend/src/components/UserDashboard.css
+++ b/helpdesk-frontend/src/components/UserDashboard.css
@@ -25,8 +25,8 @@
   box-shadow: 0 14px 38px rgba(21, 101, 192, 0.22);
 }
 
-.user-theme .logo-emi {
-  color: rgba(255, 255, 255, 0.88);
+.user-theme .emi-logo {
+  opacity: 0.94;
 }
 
 .user-theme .admin-content {

--- a/helpdesk-frontend/src/components/UserDashboard.jsx
+++ b/helpdesk-frontend/src/components/UserDashboard.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './AdminDashboard.css';
 import './UserDashboard.css';
+import emiLogo from '../assets/ESCUELA-MILITAR-DE-INGENIERIA.png';
 import TicketForm from './TicketForm';
 import TicketList from './TicketList.jsx';
 import {
@@ -78,9 +79,9 @@ export default function UserDashboard({ onLogout, token, role }) {
           <button className="menu-toggle" onClick={() => setSidebarOpen(!sidebarOpen)}>
             {sidebarOpen ? <FiX /> : <FiMenu />}
           </button>
-          <h1>
+          <h1 className="app-logo">
             <span className="logo-part">HelpDesk</span>
-            <span className="logo-emi">EMI</span>
+            <img src={emiLogo} alt="Logo EMI" className="emi-logo" />
           </h1>
         </div>
 


### PR DESCRIPTION
## Summary
- replace the EMI text label with the official EMI logo beside the HelpDesk heading across the admin, technician, and user dashboards
- update header styling to accommodate the new image while keeping theme-specific adjustments consistent

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e55a8c92f483299cd2856668e1bed9