### PR TITLE
feat: render manual manual guidance in help center

### DIFF
--- a/docs/MANUAL_USUARIO.md
+++ b/docs/MANUAL_USUARIO.md
@@ -1,124 +1,200 @@
-﻿# Manual de Usuario – HelpDesk EMI Cochabamba
-
-## Índice
-- [Introducción](#introducción)
-- [Acceso e Inicio de Sesión](#acceso-e-inicio-de-sesión)
-- [Chatbot de Soporte](#chatbot-de-soporte)
-- [Rol Solicitante](#rol-solicitante)
-- [Rol Técnico](#rol-técnico)
-- [Rol Administrador](#rol-administrador)
-- [Sección de Ayuda](#sección-de-ayuda)
-- [Glosario](#glosario)
-- [Preguntas Frecuentes](#preguntas-frecuentes)
+# Manual de Usuario – HelpDesk EMI
 
 ## Introducción
-El sistema HelpDesk EMI Cochabamba permite registrar incidencias (tickets), asignarlas a técnicos y hacer seguimiento hasta su resolución. Incluye filtros por estado, rango de fechas, buscador, calificación del servicio y un chatbot que guía a los usuarios.
-
-> Nota: Las capturas de pantalla sugeridas deben guardarse en docs/img/ con los nombres indicados. Puedes usar cualquier herramienta (Snipping Tool, Lightshot, etc.) y, si lo deseas, agregar números o resaltes para indicar zonas clave.
-
-## Acceso e Inicio de Sesión
-![Pantalla de Login](img/01-login.png)
-
-1. Usuario/Correo: escribe tus credenciales registradas.
-2. Contraseña: introduce la clave asociada a tu cuenta.
-3. Botón “Ingresar”: valida credenciales y redirige al panel correspondiente.
-4. ¿Olvidaste la contraseña / registro? (si aplica): sigue los pasos mostrados en pantalla.
-
-Flujo básico
-- Inicia sesión con tu rol (Solicitante, Técnico o Administrador).
-- El sistema te llevará al panel principal (dashboard) correspondiente.
-
-## Chatbot de Soporte
-![Chatbot](img/02-chatbot.png)
-
-1. Botón flotante “Chat/Cerrar”: abre o cierra el asistente.
-2. Encabezado “Asistente EMI – Soporte Cochabamba”: confirma que estás en el asistente oficial.
-3. Mensaje inicial: solicita tu rol (Estudiante, Docente, Administrativo).
-4. Botones de rol: selecciona el que corresponda para personalizar la conversación.
-5. Campo de texto y botón “Enviar”: escribe tus consultas; el bot puede crear tickets guiados.
-
-## Rol Solicitante
-### Listado y seguimiento de tickets
-![Solicitante – Listado](img/03-solicitante-listado.png)
-
-1. Actualizar: recarga la lista de tickets.
-2. Filtro de estado: filtra por Resueltos, Sin resolver, etc.
-3. Rango de fechas: define un periodo para listar tickets.
-4. Buscador: encuentra tickets por título, técnico, estado o fecha.
-5. Tabla: muestra detalle, técnico asignado y estado actual.
-
-### Calificar la atención
-![Calificación](img/04-calificacion.png)
-
-- Al cerrar un ticket, selecciona de 1 a 5 estrellas para valorar el servicio.
-- Esta retroalimentación ayuda al equipo de soporte a mejorar.
-
-## Rol Técnico
-### Tickets asignados y flujo de trabajo
-![Técnico – Listado](img/05-tecnico-listado.png)
-
-1. Filtro de estado: revisa pendientes, en progreso o resueltos.
-2. Botón “Marcar en progreso”: disponible cuando el ticket está Esperando/Asignado.
-3. Botón “Marcar resuelto”: disponible después de marcar en progreso.
-4. Información clave: título, descripción, solicitante y fecha.
-
-Importante: Una vez marcado como Resuelto, el botón queda deshabilitado y el ticket no puede retroceder de estado.
-
-## Rol Administrador
-### Gestión de tickets
-![Administrador – Tickets](img/06-admin-listado.png)
-
-1. Filtros globales: estado, fechas, buscador.
-2. Acciones por fila: asignar técnico, editar o eliminar.
-3. Resumen de estado: consulta el avance general y calificaciones recibidas.
-
-### Panel de asignación de técnicos
-![Asignar Técnico](img/07-asignacion.png)
-
-1. Listado de técnicos disponibles: ordenado alfabéticamente.
-2. Botón “Asignar”: confirma la asignación.
-3. Cerrar: cancela el proceso sin cambios.
-
-### Gestión de usuarios
-![Gestión de Usuarios](img/08-usuarios.png)
-
-- Crea, edita o deshabilita cuentas de solicitantes, técnicos y administradores.
-- Verifica roles correctos y datos de contacto actualizados.
-
-## Sección de Ayuda
-![Sección de Ayuda](img/09-ayuda.png)
-
-La opción Ayuda en el menú lateral muestra:
-- Guía rápida para nuevos usuarios.
-- Acceso directo al manual (docs/MANUAL_USUARIO.md).
-- Recomendaciones específicas según el rol con el que iniciaste sesión.
-- Recordatorio del chatbot como canal de apoyo inmediato.
-
-## Glosario
-- Ticket: solicitud de soporte o incidencia registrada.
-- Estados: Esperando, Asignado, En Progreso, Resuelto.
-- Calificación: valoración (1 a 5) realizada por el solicitante al cerrar un ticket.
-- Rango de fechas: filtro por fecha de creación.
-
-## Preguntas Frecuentes
-1. No encuentro mi ticket.
-   - Verifica el rango de fechas y utiliza el buscador por título o #ID.
-2. No puedo cambiar el estado como técnico.
-   - Solo puedes avanzar de Esperando/Asignado → En Progreso → Resuelto. Si el botón está deshabilitado, revisa si ya está resuelto.
-3. El chatbot no responde.
-   - Comprueba tu conexión, recarga la página o contacta al administrador.
-4. ¿Dónde está el manual actualizado?
-   - En este proyecto: docs/MANUAL_USUARIO.md. Agrega tus capturas en docs/img/ y compártelo como PDF si es necesario.
+El sistema HelpDesk EMI centraliza la gestión de incidencias tecnológicas en tres módulos diferenciados por rol: Administrador, Técnico y Usuario Solicitante. Este manual describe cada vista, explica las funciones de sus botones y provee procedimientos paso a paso para trabajar de forma segura y consistente.
 
 ---
 
-Actualización de capturas (guárdalas en docs/img/)
-- 01-login.png
-- 02-chatbot.png
-- 03-solicitante-listado.png
-- 04-calificacion.png
-- 05-tecnico-listado.png
-- 06-admin-listado.png
-- 07-asignacion.png
-- 08-usuarios.png
-- 09-ayuda.png
+## Módulo Administrador
+### 1. Pantalla principal (Dashboard)
+Al ingresar como administrador se muestra un panel ejecutivo con cuatro tarjetas de métricas:
+- **Usuarios registrados**: cantidad total de cuentas activas en la plataforma.
+- **Tickets totales**: solicitudes acumuladas desde la puesta en marcha del sistema.
+- **Tickets activos**: casos abiertos que requieren seguimiento.
+- **Satisfacción**: promedio de calificaciones registradas por los solicitantes.
+
+Bajo las tarjetas se presentan accesos rápidos a Configuración, Reportes, Lista de Tickets y Gestión de Usuarios, además de un resumen de actividad reciente para identificar novedades sin navegar a otras vistas.
+
+### 2. Menú lateral
+- 🏠 **Dashboard**: regresa a la vista principal con métricas y actividad.
+- 🔧 **Configuración**: personaliza temas de color, idioma, densidad, accesos directos y parámetros de seguridad.
+- 📊 **Reportes**: muestra el tablero analítico con indicadores, tendencias y exportación a PDF.
+- 📨 **Lista de Tickets**: abre la tabla de tickets con filtros avanzados, búsqueda y acciones por fila.
+- ➕ **Crear Tickets**: habilita el formulario para generar incidencias manuales.
+- 👥 **Usuarios**: administra cuentas (crear, editar, eliminar, asignar roles).
+- ❓ **Ayuda**: despliega el centro de ayuda con guías y recursos institucionales.
+
+### 3. Guías paso a paso
+#### 3.1 Supervisar y filtrar tickets
+1. Abrir 📨 **Lista de Tickets**.
+2. Usar los filtros de estado, rango de fechas y buscador para acotar resultados.
+3. Pulsar **Actualizar** para refrescar la información.
+4. Revisar columnas de técnico asignado, estado, fecha y calificación.
+
+#### 3.2 Asignar un ticket a un técnico
+1. Desde la lista, pulsar el botón **Asignar** (icono 👤➕) del ticket correspondiente.
+2. Seleccionar un técnico disponible en el panel lateral que se despliega.
+3. Confirmar con **Asignar**. El ticket se actualiza y la ventana se cierra.
+
+#### 3.3 Editar o eliminar tickets
+- **Editar**: pulsar el icono ✏️, ajustar título y descripción cuando se solicite y confirmar.
+- **Eliminar**: pulsar el icono 🗑️ y confirmar en la ventana emergente.
+
+#### 3.4 Crear un ticket manual
+1. Ingresar a ➕ **Crear Tickets**.
+2. Completar **Título** (obligatorio) y **Descripción** (detalles de la incidencia).
+3. Pulsar **Crear ticket** para registrar; opcionalmente usar **Limpiar** para reiniciar campos.
+
+#### 3.5 Generar reportes y exportar
+1. Entrar en 📊 **Reportes**.
+2. Revisar los bloques de resumen (totales, activos, resueltos, tiempo promedio de resolución).
+3. Analizar la distribución por estado, la tendencia de los últimos 7 días y el promedio de satisfacción.
+4. Consultar la tabla de tickets recientes.
+5. Usar **Actualizar** para recargar datos o **Exportar (PDF)** para imprimir/guardar.
+
+#### 3.6 Gestionar usuarios
+1. Seleccionar 👥 **Usuarios**.
+2. Completar el formulario con nombre, correo, contraseña y rol.
+3. Presionar **Crear usuario** (o **Actualizar usuario** si está en modo edición).
+4. Utilizar los botones ✏️/**Editar** y 🗑️/**Eliminar** sobre cada fila según corresponda.
+
+#### 3.7 Ajustar configuración del panel
+- Elegir temas (Automático, Claro, Oscuro) y densidad de la interfaz.
+- Cambiar idioma, tamaño de fuente y accesos rápidos de menú.
+- Activar controles de seguridad (verificación en dos pasos, alertas de inicio de sesión) y cerrar sesiones remotas.
+
+### 4. Consejos de uso y buenas prácticas
+- Actualice la lista de tickets antes de asignar para evitar duplicidades.
+- Priorice los tickets **Sin asignar** y los estados críticos en los reportes.
+- Revise periódicamente los accesos rápidos para mantener un menú coherente con su operación.
+- Exporte reportes mensuales para respaldar indicadores institucionales.
+- Cierre sesión al finalizar la jornada y revise las notificaciones de seguridad.
+
+### 5. Centro de Ayuda (vista ❓ Ayuda)
+> 🛎️ **Panel de ayuda del Administrador**
+>
+>| Área | ¿Qué incluye? |
+>| --- | --- |
+>| 📂 **Recursos** | Manual descargable (PDF/Markdown), carpeta de plantillas institucionales y acceso rápido al chatbot EMI. |
+>| ⚙️ **Operación diaria** | Checklist de inicio de jornada (tickets nuevos, asignaciones pendientes, alertas de seguridad) y recordatorios de cierre (exportar reportes, revisar sesiones activas). |
+>| 🧭 **Flujos guiados** | Tarjetas tipo infografía para procesos frecuentes: crear usuario, reasignar ticket, generar reporte mensual y ajustar catálogos. |
+>| 🛡️ **Seguridad y configuración** | Botones directos para cambiar contraseña, activar MFA y cerrar sesiones remotas. |
+>
+> **Buenas prácticas resaltadas**
+> 1. Revise el bloque **Operación diaria** antes de asignar tickets para evitar duplicidades.
+> 2. Utilice **Flujos guiados** para capacitar personal nuevo y homologar procedimientos.
+> 3. Descargue reportes desde **Recursos** al finalizar cada mes y respáldelos en el repositorio institucional.
+> 4. Desde **Seguridad y configuración** cierre sesión en dispositivos compartidos y revise alertas críticas.
+
+---
+
+## Módulo Técnico
+### 1. Pantalla principal (Dashboard)
+El tablero del técnico muestra un saludo personalizado, tarjetas con el número de tickets **Asignados**, **En progreso** y **Resueltos**, además de accesos rápidos para ir a la lista de casos y un listado de tickets recientes con estado y hora de creación.
+
+### 2. Menú lateral
+- 🏠 **Dashboard**: vista general con métricas personales y actividad reciente.
+- 📨 **Mis Tickets**: abre la tabla filtrada con los tickets asignados al técnico.
+- 🔧 **Configuración**: permite personalizar tema, idioma, densidad, notificaciones y seguridad (sesiones activas, autenticación adicional).
+
+### 3. Guías paso a paso
+#### 3.1 Revisar tickets asignados
+1. Ingresar en 📨 **Mis Tickets**.
+2. Utilizar filtros por estado (Pendientes, En progreso, Resueltos), rango de fechas y búsqueda libre.
+3. Ordenar la tabla según fecha, título o estado para priorizar trabajo.
+
+#### 3.2 Cambiar el estado de un ticket
+1. Desde la tabla, identificar el ticket con la columna **Cambiar estado**.
+2. Pulsar **Marcar en progreso** para iniciar la atención.
+3. Al concluir, pulsar **Marcar resuelto**. El botón se deshabilita cuando el ticket ya está finalizado.
+
+#### 3.3 Consultar tickets recientes desde el dashboard
+1. En 🏠 **Dashboard**, revisar la tabla “Tickets Recientes”.
+2. Utilizar el botón 👁️ para ampliar detalles (si está habilitado en su implementación).
+3. Verificar el tiempo transcurrido y los estados para decidir prioridades.
+
+#### 3.4 Ajustar preferencias personales
+- Cambiar tema (Automático, Claro, Oscuro), idioma y tamaño de fuente.
+- Activar/desactivar notificaciones de asignaciones, cambios de estado y recordatorios de SLA.
+- Administrar accesos rápidos del menú y revisar/cerrar sesiones activas.
+
+### 4. Consejos de uso y buenas prácticas
+- Cambie el estado a “En progreso” al iniciar el trabajo para que el solicitante conozca el avance.
+- Documente internamente hallazgos relevantes (cuando la versión instalada lo permita) antes de marcar como resuelto.
+- Revise la sección de notificaciones al comenzar la jornada.
+- Mantenga activas las alertas de inicio de sesión y finalice sesiones en dispositivos no utilizados.
+
+### 5. Centro de Ayuda (vista ❓ Ayuda)
+> 🧰 **Panel de ayuda del Técnico**
+>
+>| Área | ¿Qué incluye? |
+>| --- | --- |
+>| 🧾 **Checklist operativo** | Ruta visual “Revisión → En progreso → Resuelto → Calificación” con recordatorio de documentar hallazgos. |
+>| 🚨 **Alertas del día** | Tarjetas con tickets críticos, SLA próximos a vencer y avisos de reasignaciones recientes. |
+>| 🗒️ **Guías rápidas** | Pasos resumidos para actualizar estados, adjuntar evidencias y coordinar con soporte de segundo nivel. |
+>| 🤖 **Chatbot EMI Técnico** | Consejos para diagnóstico, escalamientos y artículos de la base de conocimiento. |
+>
+> **Buenas prácticas resaltadas**
+> 1. Actualice el estado del ticket desde **Checklist operativo** para notificar al solicitante en tiempo real.
+> 2. Priorice los casos de **Alertas del día** al iniciar la jornada para cumplir los SLA.
+> 3. Consulte **Guías rápidas** al documentar cambios de hardware/software y mantenga evidencias adjuntas.
+> 4. Use el **Chatbot EMI Técnico** cuando requiera procedimientos especializados o coordinación remota.
+
+---
+
+## Módulo Usuario Solicitante
+### 1. Pantalla principal (Dashboard)
+El solicitante encuentra un aviso de calificaciones pendientes, una bienvenida con la hora del último acceso y tres tarjetas con sus tickets **Totales**, **Activos** y **Resueltos**. También se lista la actividad reciente de sus últimas solicitudes para ubicar rápidamente el estado actual.
+
+### 2. Menú lateral
+- 🏠 **Dashboard**: resumen personal de incidencias y avisos de calificación.
+- ➕ **Nuevo Ticket**: formulario para registrar una nueva solicitud.
+- 📨 **Mis Tickets**: tabla con todos los tickets creados por el usuario, filtros y calificaciones.
+
+### 3. Guías paso a paso
+#### 3.1 Crear un nuevo ticket
+1. Seleccionar ➕ **Nuevo Ticket**.
+2. Completar **Título** (obligatorio) describiendo brevemente el problema.
+3. Agregar **Descripción** con detalles: mensajes de error, pasos realizados, horario, etc.
+4. Pulsar **Crear ticket**. El sistema confirmará con un mensaje de éxito y limpiará el formulario.
+
+#### 3.2 Consultar y filtrar mis tickets
+1. Entrar a 📨 **Mis Tickets**.
+2. Filtrar por estado (Sin resolver, Resueltos), fechas o usar la búsqueda por palabras clave.
+3. Revisar columnas de técnico asignado, estado, fecha y calificación.
+4. Presionar **Actualizar** cuando necesite recargar información.
+
+#### 3.3 Calificar la atención
+1. Cuando un ticket esté marcado como **Resuelto**, aparecerán cinco botones de estrella en la columna **Calificación**.
+2. Hacer clic en la cantidad de estrellas que represente su satisfacción (1-5).
+3. La puntuación se guardará inmediatamente y podrá consultarse posteriormente.
+
+### 4. Consejos de uso y buenas prácticas
+- Describa con precisión la incidencia para acelerar la asignación.
+- Utilice el buscador para recuperar tickets antiguos antes de crear uno nuevo.
+- Atienda los recordatorios de calificación para mantener indicadores confiables.
+- Consulte el chatbot institucional para guías rápidas antes de abrir un caso.
+- Cierre sesión al terminar, especialmente en equipos compartidos.
+
+### 5. Centro de Ayuda (vista ❓ Ayuda)
+> 💡 **Panel de ayuda del Solicitante**
+>
+>| Área | ¿Qué incluye? |
+>| --- | --- |
+>| 🚀 **Primeros pasos** | Video guiado, ejemplo de ticket bien redactado y acceso rápido al botón **Crear ticket**. |
+>| 📬 **Seguimiento y avisos** | Indicaciones para leer estados, activar recordatorios de correo y filtrar por fecha o prioridad. |
+>| ⭐ **Califica el servicio** | Explicación de las estrellas, mensaje institucional de agradecimiento y recordatorio de comentar observaciones. |
+>| 🤖 **Chatbot EMI Solicitante** | Sugerencias de autodiagnóstico, horarios extendidos y enlaces a tutoriales básicos. |
+>
+> **Consejos visibles**
+> 1. Complete los campos obligatorios antes de enviar un ticket y valide correo/teléfono en **Primeros pasos**.
+> 2. Revise **Seguimiento y avisos** cada vez que reciba notificaciones para conocer cambios de estado.
+> 3. Utilice **Califica el servicio** apenas se marque como resuelto para mantener actualizado el indicador de satisfacción.
+> 4. Consulte el **Chatbot EMI Solicitante** antes de abrir casos repetitivos; puede encontrar soluciones inmediatas.
+
+---
+
+## Recursos adicionales
+- Manual descargable: `docs/MANUAL_USUARIO.md`.
+- Carpeta sugerida para capturas: `docs/img/`.
+- Chatbot de soporte: botón flotante “Chat” disponible en la aplicación web.

--- a/helpdesk-frontend/src/components/HelpSection.css
+++ b/helpdesk-frontend/src/components/HelpSection.css
@@ -1,101 +1,375 @@
 .help-section {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  padding: 24px;
-  background: rgba(247, 250, 255, 0.9);
-  border-radius: 20px;
-  border: 1px solid rgba(12, 52, 116, 0.12);
-  box-shadow: 0 18px 36px rgba(15, 33, 71, 0.08);
+  gap: 32px;
+  padding: 32px;
+  background: linear-gradient(160deg, rgba(14, 41, 89, 0.06), rgba(32, 99, 210, 0.08));
+  border-radius: 24px;
+  border: 1px solid rgba(12, 52, 116, 0.16);
+  box-shadow: 0 24px 48px rgba(15, 33, 71, 0.12);
 }
 
 .help-section__intro {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
+  padding: 24px;
+  background: #ffffff;
+  border-radius: 20px;
+  border: 1px solid rgba(15, 33, 71, 0.08);
+  box-shadow: 0 18px 32px rgba(15, 33, 71, 0.08);
 }
 
-.help-section__intro h2 {
-  font-size: 1.75rem;
+.help-section__intro h1 {
+  margin: 0;
+  font-size: 2rem;
   font-weight: 700;
   color: #0f1f3d;
-  margin: 0;
 }
 
 .help-section__intro p {
   margin: 0;
   color: #30415d;
-  line-height: 1.6;
+  line-height: 1.7;
 }
 
 .help-section__links {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   background: rgba(32, 99, 210, 0.08);
   border: 1px solid rgba(32, 99, 210, 0.18);
   border-radius: 16px;
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  padding: 18px;
 }
 
 .help-section__links span {
-  font-weight: 600;
+  font-weight: 700;
   color: #1c3f81;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
 }
 
 .help-section__links ul {
   margin: 0;
   padding-left: 20px;
   color: #1f2d40;
+  line-height: 1.6;
 }
 
-.help-section__grid {
+.help-section__links code {
+  background: rgba(12, 52, 116, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #0f1f3d;
+}
+
+.manual-modules {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.manual-module {
+  background: #ffffff;
+  border-radius: 24px;
+  border: 1px solid rgba(15, 33, 71, 0.12);
+  box-shadow: 0 22px 44px rgba(15, 33, 71, 0.12);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+}
+
+.manual-module__header {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(12, 52, 116, 0.12);
+}
+
+.manual-module__icon {
+  font-size: 2.6rem;
+  line-height: 1;
+  filter: drop-shadow(0 6px 12px rgba(15, 33, 71, 0.15));
+}
+
+.manual-module__header h2 {
+  margin: 0 0 6px;
+  font-size: 1.6rem;
+  color: #132b5a;
+}
+
+.manual-module__header p {
+  margin: 0;
+  color: #3b4e6a;
+  line-height: 1.6;
+}
+
+.manual-section {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 4px 0;
+}
+
+.manual-section__header {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.manual-section__badge {
+  background: linear-gradient(140deg, #205fdd, #0f1f3d);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 0.95rem;
+  padding: 8px 14px;
+  border-radius: 12px;
+  min-width: 48px;
+  text-align: center;
+  box-shadow: 0 14px 24px rgba(15, 33, 71, 0.2);
+}
+
+.manual-section__header h3 {
+  margin: 0 0 6px;
+  font-size: 1.35rem;
+  color: #122950;
+}
+
+.manual-section__header p {
+  margin: 0;
+  color: #425673;
+  line-height: 1.6;
+}
+
+.manual-card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
 }
 
-.help-topic {
-  background: #fff;
+.manual-card {
+  background: linear-gradient(160deg, rgba(32, 99, 210, 0.12), rgba(14, 41, 89, 0.08));
   border-radius: 16px;
-  border: 1px solid rgba(15, 33, 71, 0.08);
+  padding: 18px;
+  border: 1px solid rgba(12, 52, 116, 0.12);
+  box-shadow: 0 16px 28px rgba(15, 33, 71, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.manual-card h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #102347;
+}
+
+.manual-card p {
+  margin: 0;
+  color: #293b57;
+  line-height: 1.55;
+}
+
+.manual-note {
+  margin: 0;
+  padding: 14px 18px;
+  border-left: 4px solid #205fdd;
+  background: rgba(32, 99, 210, 0.08);
+  color: #1c2f4d;
+  border-radius: 12px;
+  line-height: 1.6;
+}
+
+.manual-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.manual-menu li {
+  display: flex;
+  gap: 14px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  border: 1px solid rgba(12, 52, 116, 0.1);
+  background: rgba(247, 250, 255, 0.9);
+  box-shadow: 0 12px 20px rgba(15, 33, 71, 0.08);
+}
+
+.manual-menu__icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.manual-menu h4 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #0f1f3d;
+}
+
+.manual-menu p {
+  margin: 0;
+  color: #3a4c6a;
+  line-height: 1.6;
+}
+
+.manual-guide-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.manual-guide {
+  border-radius: 18px;
+  border: 1px solid rgba(12, 52, 116, 0.12);
   padding: 18px 20px;
-  box-shadow: 0 12px 24px rgba(15, 33, 71, 0.08);
+  background: #f7faff;
+  box-shadow: inset 0 2px 0 rgba(32, 99, 210, 0.18);
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.help-topic header h3 {
-  margin: 0 0 6px;
-  font-size: 1.1rem;
-  color: #133365;
-}
-
-.help-topic header p {
+.manual-guide h4 {
   margin: 0;
-  color: #45546b;
-  line-height: 1.5;
+  font-size: 1.05rem;
+  color: #132b5a;
 }
 
-.help-topic ol {
+.manual-guide ol {
   margin: 0;
   padding-left: 20px;
   color: #2f3e55;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  line-height: 1.55;
+}
+
+.manual-list {
+  margin: 0;
+  padding-left: 22px;
+  color: #2f3e55;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  line-height: 1.6;
+}
+
+.manual-help-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(32, 99, 210, 0.18);
+  background: linear-gradient(140deg, rgba(32, 99, 210, 0.12), rgba(14, 41, 89, 0.08));
+  box-shadow: 0 16px 28px rgba(15, 33, 71, 0.12);
+}
+
+.manual-help-panel h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f1f3d;
+}
+
+.manual-help-panel table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #ffffff;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 14px 24px rgba(15, 33, 71, 0.1);
+}
+
+.manual-help-panel th,
+.manual-help-panel td {
+  padding: 14px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(12, 52, 116, 0.08);
+}
+
+.manual-help-panel th {
+  background: rgba(14, 41, 89, 0.08);
+  font-weight: 700;
+  color: #132b5a;
+  font-size: 0.95rem;
+}
+
+.manual-help-panel td {
+  color: #314565;
+  line-height: 1.6;
+}
+
+.manual-help-panel tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.manual-table-icon {
+  margin-right: 8px;
+  font-size: 1.2rem;
+}
+
+.manual-help-panel__notes {
+  background: rgba(15, 33, 71, 0.06);
+  border-radius: 14px;
+  padding: 16px 18px;
+  border: 1px solid rgba(12, 52, 116, 0.12);
+}
+
+.manual-help-panel__notes h5 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: #122950;
+}
+
+.manual-help-panel__notes ol {
+  margin: 0;
+  padding-left: 22px;
+  color: #2f3e55;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  line-height: 1.6;
+}
+
+@media (max-width: 960px) {
+  .help-section {
+    padding: 24px;
+  }
+
+  .manual-module {
+    padding: 24px;
+  }
 }
 
 @media (max-width: 720px) {
   .help-section {
-    padding: 18px;
+    padding: 20px;
   }
 
-  .help-section__grid {
-    grid-template-columns: 1fr;
+  .help-section__intro {
+    padding: 20px;
+  }
+
+  .manual-module__header {
+    flex-direction: column;
+  }
+
+  .manual-section__header {
+    flex-direction: column;
+  }
+
+  .manual-section__badge {
+    align-self: flex-start;
   }
 }

--- a/helpdesk-frontend/src/components/HelpSection.jsx
+++ b/helpdesk-frontend/src/components/HelpSection.jsx
@@ -1,142 +1,612 @@
 import React from 'react';
 import './HelpSection.css';
 
-const GENERAL_TOPICS = [
-  {
-    title: 'Guía rápida',
+const MODULE_MANUAL = {
+  Administrador: {
+    icon: '🏛️',
+    title: 'Módulo Administrador',
     description:
-      'Sigue estos pasos si recién ingresas: inicia sesión, revisa la bandeja principal y utiliza el chatbot si necesitas ayuda inmediata.',
-    steps: [
-      'Inicia sesión con tus credenciales asignadas.',
-      'Desde el menú lateral elige la sección que necesitas (Mis tickets, Nuevo ticket, etc.).',
-      'Usa el buscador y los filtros para ubicar tickets rápidamente.',
-      'Consulta el chatbot (botón "Chat") para preguntas frecuentes y creación guiada de tickets.'
+      'Supervisa la operación completa del HelpDesk EMI: asigna tickets, controla configuraciones, genera reportes y gestiona usuarios.',
+    sections: [
+      {
+        type: 'dashboard',
+        order: '1',
+        title: 'Pantalla principal (Dashboard)',
+        description:
+          'Al ingresar como administrador verás un panel ejecutivo con métricas clave y accesos rápidos a las áreas más utilizadas.',
+        cards: [
+          {
+            title: 'Usuarios registrados',
+            description: 'Cantidad total de cuentas activas en la plataforma.'
+          },
+          {
+            title: 'Tickets totales',
+            description: 'Solicitudes acumuladas desde la puesta en marcha del sistema.'
+          },
+          {
+            title: 'Tickets activos',
+            description: 'Casos abiertos que requieren seguimiento inmediato.'
+          },
+          {
+            title: 'Satisfacción',
+            description: 'Promedio de calificaciones registradas por los solicitantes.'
+          }
+        ],
+        note:
+          'Bajo las tarjetas se muestran accesos a Configuración, Reportes, Lista de Tickets y Gestión de Usuarios, junto con un resumen de actividad reciente.'
+      },
+      {
+        type: 'menu',
+        order: '2',
+        title: 'Menú lateral',
+        items: [
+          { icon: '🏠', label: 'Dashboard', description: 'Regresa a la vista principal con métricas y actividad.' },
+          {
+            icon: '🔧',
+            label: 'Configuración',
+            description: 'Personaliza temas de color, idioma, densidad, accesos directos y parámetros de seguridad.'
+          },
+          { icon: '📊', label: 'Reportes', description: 'Tablero analítico con indicadores, tendencias y exportación a PDF.' },
+          {
+            icon: '📨',
+            label: 'Lista de Tickets',
+            description: 'Tabla completa de tickets con filtros avanzados, búsqueda y acciones por fila.'
+          },
+          { icon: '➕', label: 'Crear Tickets', description: 'Formulario para registrar incidencias manuales.' },
+          { icon: '👥', label: 'Usuarios', description: 'Crea, edita, deshabilita y asigna roles a las cuentas.' },
+          { icon: '❓', label: 'Ayuda', description: 'Centro con guías, recordatorios e ingreso al manual completo.' }
+        ]
+      },
+      {
+        type: 'guides',
+        order: '3',
+        title: 'Guías paso a paso',
+        guides: [
+          {
+            subtitle: '3.1 Supervisar y filtrar tickets',
+            steps: [
+              'Abrir 📨 Lista de Tickets.',
+              'Aplicar filtros por estado, fecha o buscar por palabras clave.',
+              'Pulsar “Actualizar” para refrescar la información.',
+              'Revisar columnas de técnico asignado, estado, fecha y calificación.'
+            ]
+          },
+          {
+            subtitle: '3.2 Asignar un ticket a un técnico',
+            steps: [
+              'Desde la tabla, pulsar el botón “Asignar” (icono 👤➕) del ticket correspondiente.',
+              'Elegir un técnico disponible en el panel lateral.',
+              'Confirmar con “Asignar” para notificar al técnico.'
+            ]
+          },
+          {
+            subtitle: '3.3 Editar o eliminar tickets',
+            steps: [
+              'Seleccionar ✏️ Editar para ajustar título y descripción y guardar cambios.',
+              'Usar 🗑️ Eliminar únicamente cuando el ticket se canceló o se ingresó por error.'
+            ]
+          },
+          {
+            subtitle: '3.4 Crear un ticket manual',
+            steps: [
+              'Ingresar a ➕ Crear Tickets.',
+              'Completar título y descripción detallada de la incidencia.',
+              'Pulsar “Crear ticket”. Opcionalmente usar “Limpiar” para reiniciar campos.'
+            ]
+          },
+          {
+            subtitle: '3.5 Generar reportes y exportar',
+            steps: [
+              'Abrir 📊 Reportes y revisar bloques de totales, activos, resueltos y tiempo promedio.',
+              'Analizar las gráficas de distribución, tendencia y satisfacción.',
+              'Usar “Actualizar” para refrescar datos o “Exportar (PDF)” para compartirlos.'
+            ]
+          },
+          {
+            subtitle: '3.6 Gestionar usuarios',
+            steps: [
+              'Ingresar a 👥 Usuarios para crear o editar cuentas.',
+              'Asignar el rol correcto (Solicitante, Técnico o Administrador).',
+              'Actualizar datos de contacto o restablecer contraseñas según se requiera.'
+            ]
+          },
+          {
+            subtitle: '3.7 Ajustar configuración del panel',
+            steps: [
+              'Configurar tema, densidad, idioma y tamaño de fuente en 🔧 Configuración.',
+              'Activar verificaciones de seguridad y cerrar sesiones remotas cuando sea necesario.'
+            ]
+          }
+        ]
+      },
+      {
+        type: 'bestPractices',
+        order: '4',
+        title: 'Consejos de uso y buenas prácticas',
+        items: [
+          'Actualiza la lista de tickets antes de asignar para evitar duplicidades.',
+          'Prioriza los tickets “Sin asignar” y los estados críticos en los reportes.',
+          'Revisa y ajusta los accesos rápidos para mantener un menú alineado a tu operación.',
+          'Exporta reportes mensuales como respaldo institucional.',
+          'Cierra sesión al finalizar la jornada y revisa alertas de seguridad.'
+        ]
+      },
+      {
+        type: 'helpPanel',
+        order: '5',
+        title: 'Centro de Ayuda (vista ❓ Ayuda)',
+        panelTitle: '🛎️ Panel de ayuda del Administrador',
+        areas: [
+          {
+            icon: '📂',
+            label: 'Recursos',
+            description: 'Manual descargable, plantillas institucionales y acceso directo al chatbot EMI.'
+          },
+          {
+            icon: '⚙️',
+            label: 'Operación diaria',
+            description: 'Checklist con tickets nuevos, asignaciones pendientes y alertas de seguridad.'
+          },
+          {
+            icon: '🧭',
+            label: 'Flujos guiados',
+            description: 'Tarjetas con procesos frecuentes: crear usuario, reasignar ticket, generar reporte y ajustar catálogos.'
+          },
+          {
+            icon: '🛡️',
+            label: 'Seguridad y configuración',
+            description: 'Accesos para cambiar contraseña, activar MFA y cerrar sesiones remotas.'
+          }
+        ],
+        highlightsTitle: 'Buenas prácticas resaltadas',
+        highlights: [
+          'Revisa Operación diaria antes de asignar tickets para evitar duplicidades.',
+          'Utiliza Flujos guiados para capacitar nuevo personal y homologar procedimientos.',
+          'Descarga reportes desde Recursos al cierre de mes y respáldalos en el repositorio institucional.',
+          'Desde Seguridad y configuración cierra sesiones en dispositivos compartidos y atiende alertas críticas.'
+        ]
+      }
     ]
   },
-  {
-    title: 'Manual completo',
+  Tecnico: {
+    icon: '🧰',
+    title: 'Módulo Técnico',
     description:
-      'Encuentra el manual con capturas y explicación detallada en docs/MANUAL_USUARIO.md. Puedes convertirlo a PDF o imprimirlo.',
-    steps: [
-      'Abrir el archivo docs/MANUAL_USUARIO.md dentro del proyecto.',
-      'Completar las capturas indicadas en docs/img/* (o solicitar al administrador que las añada).',
-      'Compartir el manual actualizado con los usuarios finales (PDF o enlace interno).'
+      'Administra tus tickets asignados, avanza estados, documenta hallazgos y conserva indicadores de servicio al día.',
+    sections: [
+      {
+        type: 'dashboard',
+        order: '1',
+        title: 'Pantalla principal (Dashboard)',
+        description:
+          'El tablero muestra un saludo, tarjetas con tickets asignados, en progreso y resueltos, además de accesos rápidos y actividad reciente.',
+        cards: [
+          {
+            title: 'Asignados',
+            description: 'Cantidad de casos que requieren atención inmediata.'
+          },
+          {
+            title: 'En progreso',
+            description: 'Tickets que ya están en tratamiento y deben actualizarse con frecuencia.'
+          },
+          {
+            title: 'Resueltos',
+            description: 'Historial de incidencias finalizadas para seguimiento de desempeño.'
+          }
+        ],
+        note:
+          'La sección de tickets recientes detalla estado y hora de creación para ayudarte a planificar prioridades.'
+      },
+      {
+        type: 'menu',
+        order: '2',
+        title: 'Menú lateral',
+        items: [
+          { icon: '🏠', label: 'Dashboard', description: 'Vista general con métricas personales y actividad reciente.' },
+          {
+            icon: '📨',
+            label: 'Mis Tickets',
+            description: 'Tabla filtrada con todos los casos asignados, incluyendo buscador y filtros.'
+          },
+          {
+            icon: '🔧',
+            label: 'Configuración',
+            description: 'Preferencias de tema, idioma, densidad, notificaciones y seguridad.'
+          }
+        ]
+      },
+      {
+        type: 'guides',
+        order: '3',
+        title: 'Guías paso a paso',
+        guides: [
+          {
+            subtitle: '3.1 Revisar tickets asignados',
+            steps: [
+              'Entrar en 📨 Mis Tickets.',
+              'Filtrar por estado (Pendientes, En progreso, Resueltos), fecha o búsqueda libre.',
+              'Ordenar la tabla por fecha, título o estado para priorizar el trabajo.'
+            ]
+          },
+          {
+            subtitle: '3.2 Cambiar el estado de un ticket',
+            steps: [
+              'Identificar el ticket y usar el botón “Marcar en progreso” al iniciar la atención.',
+              'Registrar notas o comentarios técnicos cuando la implementación lo permita.',
+              'Pulsar “Marcar resuelto” al concluir para notificar al solicitante.'
+            ]
+          },
+          {
+            subtitle: '3.3 Consultar tickets recientes desde el dashboard',
+            steps: [
+              'En 🏠 Dashboard, revisar la tabla “Tickets Recientes”.',
+              'Utilizar el botón 👁️ para ampliar detalles si está disponible.',
+              'Verificar tiempos transcurridos y estados para decidir prioridades.'
+            ]
+          },
+          {
+            subtitle: '3.4 Ajustar preferencias personales',
+            steps: [
+              'En 🔧 Configuración elige tema (Automático, Claro, Oscuro), idioma y tamaño de fuente.',
+              'Activa o desactiva notificaciones de asignaciones, cambios de estado y recordatorios de SLA.',
+              'Revisa y cierra sesiones activas en dispositivos que ya no utilices.'
+            ]
+          }
+        ]
+      },
+      {
+        type: 'bestPractices',
+        order: '4',
+        title: 'Consejos de uso y buenas prácticas',
+        items: [
+          'Cambia el estado a “En progreso” al iniciar el trabajo para informar al solicitante.',
+          'Documenta hallazgos y evidencia antes de marcar un ticket como resuelto.',
+          'Revisa notificaciones y alertas al comenzar la jornada.',
+          'Mantén activas las alertas de inicio de sesión y cierra sesiones no utilizadas.'
+        ]
+      },
+      {
+        type: 'helpPanel',
+        order: '5',
+        title: 'Centro de Ayuda (vista ❓ Ayuda)',
+        panelTitle: '🧰 Panel de ayuda del Técnico',
+        areas: [
+          {
+            icon: '🧾',
+            label: 'Checklist operativo',
+            description: 'Ruta visual Revisión → En progreso → Resuelto → Calificación, con recordatorio de documentar hallazgos.'
+          },
+          {
+            icon: '🚨',
+            label: 'Alertas del día',
+            description: 'Tarjetas con tickets críticos, SLA próximos a vencer y reasignaciones recientes.'
+          },
+          {
+            icon: '🗒️',
+            label: 'Guías rápidas',
+            description: 'Pasos resumidos para actualizar estados, adjuntar evidencias y coordinar con soporte de segundo nivel.'
+          },
+          {
+            icon: '🤖',
+            label: 'Chatbot EMI Técnico',
+            description: 'Consejos de diagnóstico, escalamientos y artículos de la base de conocimiento.'
+          }
+        ],
+        highlightsTitle: 'Buenas prácticas resaltadas',
+        highlights: [
+          'Actualiza el estado desde Checklist operativo para informar al solicitante en tiempo real.',
+          'Prioriza las Alertas del día para cumplir con los SLA comprometidos.',
+          'Consulta Guías rápidas al documentar cambios y mantener evidencias adjuntas.',
+          'Utiliza el Chatbot EMI Técnico para acceder a procedimientos especializados o coordinar soporte remoto.'
+        ]
+      }
     ]
   },
-  {
-    title: 'Sugerencias generales',
-    description: 'Recomendaciones transversales para todos los roles.',
-    steps: [
-      'Mantén tus datos de contacto actualizados para recibir notificaciones de tickets.',
-      'Califica la atención al cerrar un ticket para mejorar el servicio.',
-      'Si detectas un error en el sistema, crea un ticket etiquetado como "Incidencia" para que soporte técnico lo atienda.'
+  Solicitante: {
+    icon: '💡',
+    title: 'Módulo Usuario Solicitante',
+    description:
+      'Registra incidencias, da seguimiento a tus solicitudes y califica la atención recibida de forma rápida y ordenada.',
+    sections: [
+      {
+        type: 'dashboard',
+        order: '1',
+        title: 'Pantalla principal (Dashboard)',
+        description:
+          'La vista principal muestra recordatorios de calificación, la hora de tu último acceso y tarjetas con el resumen de tickets.',
+        cards: [
+          {
+            title: 'Tickets totales',
+            description: 'Cantidad acumulada de solicitudes que has registrado.'
+          },
+          {
+            title: 'Tickets activos',
+            description: 'Casos que aún están abiertos y requieren seguimiento.'
+          },
+          {
+            title: 'Tickets resueltos',
+            description: 'Incidencias finalizadas disponibles para consultar historial y calificar.'
+          }
+        ],
+        note:
+          'La actividad reciente lista los últimos movimientos para que ubiques rápidamente el estado de cada solicitud.'
+      },
+      {
+        type: 'menu',
+        order: '2',
+        title: 'Menú lateral',
+        items: [
+          { icon: '🏠', label: 'Dashboard', description: 'Resumen personal de incidencias y avisos de calificación.' },
+          { icon: '➕', label: 'Nuevo Ticket', description: 'Formulario para registrar una nueva solicitud con detalles y evidencias.' },
+          {
+            icon: '📨',
+            label: 'Mis Tickets',
+            description: 'Tabla con todas tus solicitudes, filtros por estado y acceso a la calificación de servicio.'
+          }
+        ]
+      },
+      {
+        type: 'guides',
+        order: '3',
+        title: 'Guías paso a paso',
+        guides: [
+          {
+            subtitle: '3.1 Crear un nuevo ticket',
+            steps: [
+              'Seleccionar ➕ Nuevo Ticket.',
+              'Completar el título describiendo brevemente la incidencia.',
+              'Agregar una descripción detallada con mensajes de error, pasos realizados y horarios.',
+              'Pulsar “Crear ticket”. El sistema confirmará y limpiará el formulario.'
+            ]
+          },
+          {
+            subtitle: '3.2 Consultar y filtrar mis tickets',
+            steps: [
+              'Entrar a 📨 Mis Tickets.',
+              'Filtrar por estado (Sin resolver, Resueltos), rango de fechas o buscar por palabras clave.',
+              'Revisar técnico asignado, estado, fecha y calificación antes de abrir un nuevo caso.',
+              'Presionar “Actualizar” para recargar información.'
+            ]
+          },
+          {
+            subtitle: '3.3 Calificar la atención',
+            steps: [
+              'Cuando un ticket esté resuelto aparecerán cinco estrellas en la columna Calificación.',
+              'Selecciona el número de estrellas que represente tu satisfacción (1-5).',
+              'La puntuación se guarda al instante y queda disponible para consulta futura.'
+            ]
+          }
+        ]
+      },
+      {
+        type: 'bestPractices',
+        order: '4',
+        title: 'Consejos de uso y buenas prácticas',
+        items: [
+          'Describe la incidencia con precisión para acelerar la asignación de un técnico.',
+          'Usa el buscador antes de crear un ticket nuevo y evita duplicar solicitudes.',
+          'Responde a los recordatorios de calificación para mantener indicadores confiables.',
+          'Consulta el chatbot institucional para guías rápidas antes de abrir un caso.',
+          'Cierra sesión al terminar, especialmente si utilizas equipos compartidos.'
+        ]
+      },
+      {
+        type: 'helpPanel',
+        order: '5',
+        title: 'Centro de Ayuda (vista ❓ Ayuda)',
+        panelTitle: '💡 Panel de ayuda del Solicitante',
+        areas: [
+          {
+            icon: '🚀',
+            label: 'Primeros pasos',
+            description: 'Video guiado, ejemplo de ticket bien redactado y acceso directo a Crear ticket.'
+          },
+          {
+            icon: '📬',
+            label: 'Seguimiento y avisos',
+            description: 'Indicaciones para leer estados, activar recordatorios de correo y filtrar por fecha o prioridad.'
+          },
+          {
+            icon: '⭐',
+            label: 'Califica el servicio',
+            description: 'Explicación de las estrellas y recordatorio institucional para compartir comentarios.'
+          },
+          {
+            icon: '🤖',
+            label: 'Chatbot EMI Solicitante',
+            description: 'Sugerencias de autodiagnóstico, horarios extendidos y enlaces a tutoriales básicos.'
+          }
+        ],
+        highlightsTitle: 'Consejos visibles',
+        highlights: [
+          'Completa los campos obligatorios y valida correo/teléfono en Primeros pasos antes de enviar.',
+          'Consulta Seguimiento y avisos cuando recibas notificaciones para conocer cambios de estado.',
+          'Califica el servicio apenas se marque un ticket como resuelto para actualizar el indicador de satisfacción.',
+          'Recurre al Chatbot EMI Solicitante para resolver dudas frecuentes sin abrir casos repetitivos.'
+        ]
+      }
     ]
   }
-];
-
-const ROLE_TOPICS = {
-  Solicitante: [
-    {
-      title: 'Crear y seguir tus tickets',
-      description:
-        'Registra incidencias desde "Nuevo ticket" o mediante el chatbot. Haz seguimiento en "Mis tickets".',
-      steps: [
-        'Completa título y descripción con el mayor detalle posible.',
-        'Adjunta información relevante si el formulario lo permite.',
-        'Utiliza los filtros por fecha y estado para encontrar tickets antiguos.',
-        'Cuando el ticket se resuelva, califica la atención desde la columna "Calificación".'
-      ]
-    }
-  ],
-  Tecnico: [
-    {
-      title: 'Gestionar tickets asignados',
-      description:
-        'Solo puedes avanzar un ticket a "En Progreso" y luego a "Resuelto". Planifica tu trabajo con la vista "Tickets asignados".',
-      steps: [
-        'Usa el botón "Marcar en progreso" cuando comiences a trabajar.',
-        'Agrega notas internas o comentarios si la funcionalidad está disponible.',
-        'Al terminar, presiona "Marcar resuelto" para notificar al solicitante.',
-        'Monitorea la retroalimentación recibida para mejorar el servicio.'
-      ]
-    }
-  ],
-  Administrador: [
-    {
-      title: 'Supervisar y asignar tickets',
-      description:
-        'Desde la sección "Tickets" puedes asignar incidencias, editar información y monitorear el estado del flujo completo.',
-      steps: [
-        'Filtra por estado "Sin asignar" para atender nuevas solicitudes.',
-        'Asigna un técnico disponible desde el panel lateral (botón "Asignar").',
-        'Utiliza la búsqueda por #ID, título, solicitante o técnico para búsquedas avanzadas.',
-        'Genera reportes y exporta información si tu implementación lo permite.'
-      ]
-    },
-    {
-      title: 'Gestión de usuarios y configuración',
-      description:
-        'La sección "Usuarios" (si está habilitada) te permite crear, editar o deshabilitar cuentas.',
-      steps: [
-        'Verifica que cada usuario tenga el rol correcto (Solicitante, Técnico, Administrador).',
-        'Actualiza datos de contacto y restablece contraseñas cuando sea necesario.',
-        'Revisa periódicamente los dashboards de reportes para detectar cuellos de botella.'
-      ]
-    }
-  ]
 };
 
-function HelpTopic({ title, description, steps }) {
+function SectionHeader({ order, title, description }) {
   return (
-    <section className="help-topic">
-      <header>
+    <header className="manual-section__header">
+      <span className="manual-section__badge">{order}</span>
+      <div>
         <h3>{title}</h3>
         {description && <p>{description}</p>}
-      </header>
-      {steps && steps.length > 0 && (
-        <ol>
-          {steps.map((step, index) => (
-            <li key={index}>{step}</li>
-          ))}
-        </ol>
-      )}
+      </div>
+    </header>
+  );
+}
+
+function DashboardSection({ section }) {
+  return (
+    <section className="manual-section">
+      <SectionHeader order={section.order} title={section.title} description={section.description} />
+      <div className="manual-card-grid">
+        {section.cards.map((card) => (
+          <div key={card.title} className="manual-card">
+            <h4>{card.title}</h4>
+            <p>{card.description}</p>
+          </div>
+        ))}
+      </div>
+      {section.note && <p className="manual-note">{section.note}</p>}
     </section>
   );
 }
 
+function MenuSection({ section }) {
+  return (
+    <section className="manual-section">
+      <SectionHeader order={section.order} title={section.title} />
+      <ul className="manual-menu">
+        {section.items.map((item) => (
+          <li key={item.label}>
+            <span className="manual-menu__icon">{item.icon}</span>
+            <div>
+              <h4>{item.label}</h4>
+              <p>{item.description}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function GuidesSection({ section }) {
+  return (
+    <section className="manual-section">
+      <SectionHeader order={section.order} title={section.title} />
+      <div className="manual-guide-grid">
+        {section.guides.map((guide) => (
+          <article key={guide.subtitle} className="manual-guide">
+            <h4>{guide.subtitle}</h4>
+            <ol>
+              {guide.steps.map((step, index) => (
+                <li key={index}>{step}</li>
+              ))}
+            </ol>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BestPracticesSection({ section }) {
+  return (
+    <section className="manual-section">
+      <SectionHeader order={section.order} title={section.title} />
+      <ul className="manual-list">
+        {section.items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function HelpPanelSection({ section }) {
+  return (
+    <section className="manual-section">
+      <SectionHeader order={section.order} title={section.title} />
+      <div className="manual-help-panel">
+        <h4>{section.panelTitle}</h4>
+        <table>
+          <thead>
+            <tr>
+              <th>Área</th>
+              <th>¿Qué incluye?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {section.areas.map((area) => (
+              <tr key={area.label}>
+                <td>
+                  <span className="manual-table-icon">{area.icon}</span>
+                  {area.label}
+                </td>
+                <td>{area.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="manual-help-panel__notes">
+          <h5>{section.highlightsTitle}</h5>
+          <ol>
+            {section.highlights.map((highlight, index) => (
+              <li key={index}>{highlight}</li>
+            ))}
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ManualModule({ moduleKey, data }) {
+  return (
+    <article className="manual-module" id={`manual-${moduleKey.toLowerCase()}`}>
+      <header className="manual-module__header">
+        <span className="manual-module__icon" aria-hidden>{data.icon}</span>
+        <div>
+          <h2>{data.title}</h2>
+          <p>{data.description}</p>
+        </div>
+      </header>
+
+      {data.sections.map((section) => {
+        switch (section.type) {
+          case 'dashboard':
+            return <DashboardSection key={section.title} section={section} />;
+          case 'menu':
+            return <MenuSection key={section.title} section={section} />;
+          case 'guides':
+            return <GuidesSection key={section.title} section={section} />;
+          case 'bestPractices':
+            return <BestPracticesSection key={section.title} section={section} />;
+          case 'helpPanel':
+            return <HelpPanelSection key={section.title} section={section} />;
+          default:
+            return null;
+        }
+      })}
+    </article>
+  );
+}
+
 export default function HelpSection({ role = 'Solicitante' }) {
-  const roleSpecific = ROLE_TOPICS[role] || [];
+  const normalizedRole = role === 'Administrador' ? 'Administrador' : role === 'Tecnico' ? 'Tecnico' : 'Solicitante';
+  const modulesToRender =
+    normalizedRole === 'Administrador' ? ['Administrador', 'Tecnico', 'Solicitante'] : [normalizedRole];
 
   return (
     <div className="help-section">
-      <div className="help-section__intro">
-        <h2>Centro de ayuda</h2>
+      <header className="help-section__intro">
+        <h1>Manual interactivo – HelpDesk EMI</h1>
         <p>
-          Aquí encontrarás atajos, recomendaciones y acceso al manual para aprovechar el sistema de soporte.
-          Si necesitas asistencia inmediata, inicia el chatbot o contacta al administrador.
+          Consulta procedimientos oficiales, menús y buenas prácticas según tu rol. El Administrador puede visualizar los tres módulos para
+          capacitar al personal y garantizar la correcta operación del servicio institucional.
         </p>
         <div className="help-section__links">
-          <span>Recursos:</span>
+          <span>Recursos rápidos</span>
           <ul>
             <li>
-              Manual descargable: <code>docs/MANUAL_USUARIO.md</code>
+              📘 Manual descargable: <code>docs/MANUAL_USUARIO.md</code>
             </li>
-            <li>
-              Carpeta de capturas sugeridas: <code>docs/img/</code>
-            </li>
-            <li>
-              Chatbot de soporte (botón "Chat" en la esquina inferior derecha).
-            </li>
+            <li>🗂️ Carpeta de capturas sugeridas: <code>docs/img/</code></li>
+            <li>🤖 Chatbot EMI: botón flotante “Chat” disponible en toda la aplicación.</li>
           </ul>
         </div>
-      </div>
+      </header>
 
-      <div className="help-section__grid">
-        {GENERAL_TOPICS.map((topic) => (
-          <HelpTopic key={topic.title} {...topic} />
-        ))}
-        {roleSpecific.map((topic) => (
-          <HelpTopic key={topic.title} {...topic} />
+      <div className="manual-modules">
+        {modulesToRender.map((moduleKey) => (
+          <ManualModule key={moduleKey} moduleKey={moduleKey} data={MODULE_MANUAL[moduleKey]} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- embed the full administrator, técnico y solicitante manual content directly into the HelpSection component with role-aware rendering
- redesign the help center layout with structured cards, tables and guide blocks so it reads like an institutional manual
- refresh the associated styles to deliver a polished, EMI-branded presentation for each module

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e56f46ceb48329b00418dca27ed113